### PR TITLE
Fix Add function to add both a and b

### DIFF
--- a/rogue_math.rb
+++ b/rogue_math.rb
@@ -1,6 +1,6 @@
 class RogueMath
   def self.add(a, b)
-    a + a
+    a + b
   end
 
   def self.subtract(a, b)

--- a/spec/rogue_math_spec.rb
+++ b/spec/rogue_math_spec.rb
@@ -3,9 +3,9 @@ require_relative "../rogue_math.rb"
 describe RogueMath do
   describe "add" do
     let(:a) { 2 }
-    let(:b) { 2 }
+    let(:b) { 3 }
 
-    specify { expect(described_class.add(a, b)).to eq 4 }
+    specify { expect(described_class.add(a, b)).to eq 5 }
   end
 
   describe "subtract" do


### PR DESCRIPTION
Previously the linter caught an unused variable.

This was a bug and this commit now uses both the a and b variables in the add method.